### PR TITLE
Fixed scheffe.test for mixed models

### DIFF
--- a/R/scheffe.test.R
+++ b/R/scheffe.test.R
@@ -52,7 +52,7 @@
 #' print(out)
 #' 
 scheffe.test <-
-function (y, trt, DFerror, MSerror, Fc, alpha=0.05, group=TRUE,main = NULL,console=FALSE)
+function (y, trt, DFerror, MSerror, Fc, alpha=0.05, group=TRUE,main = NULL,console=FALSE, mixm=FALSE)
 {
 	name.y <- paste(deparse(substitute(y)))
 	name.t <- paste(deparse(substitute(trt)))
@@ -63,7 +63,11 @@ function (y, trt, DFerror, MSerror, Fc, alpha=0.05, group=TRUE,main = NULL,conso
 		A<-y$model
 		DFerror<-df.residual(y)
 		MSerror<-deviance(y)/DFerror
-		Fc<-anova(y)[trt,4]
+		if (mixm == FALSE){
+			Fc<-anova(y)[trt,4]
+		}else{
+			anova(y)$anova[trt, 4]
+		}
 		y<-A[,1]
 		ipch<-pmatch(trt,names(A))
 		nipch<- length(ipch)


### PR DESCRIPTION
I was working with the "mixlm" package, utilizing the lm() function to construct a mixed model, which consists of two factors one fixed and the other random. However, when I attempted to perform the Scheffe test using scheffe.test(mixed_model, trt = "fixed_factor"), I encountered the following error: _"Error in anova(y)[trt, 4]: incorrect number of dimensions."_

The model was: **lm(response ~ fixed_factor + r(random_factor) + fixed_factor:r(random_factor), unrestricted = F)**

I identified that this error comes from the disparity in the output of anova(mixed_model), which is distinct from the output of a model with two fixed factors. This discrepancy affects the localization of the F-value.

To address this issue, I added a new argument, **mixm**, to the function. By default, mixm is set to FALSE.

When mixm is set to FALSE, the F-value is located as follows:  **Fc <- anova(y)[trt, 4]**
When mixm is set to TRUE, the F-value is located as follows:  **Fc <- anova(y)$anova[trt, 4]** (for mixed models)

This modification ensures that the F-value is accurately retrieved based on the user's choice of the mixm parameter.